### PR TITLE
Add require_interaction option to make notification sticky.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,5 @@ ip.register_magics(jupyternotify.JupyterNotifyMagics(
 
 The following options exist:
 - `require_interaction` - Boolean, default False. When this is true,
-  notifications will remain on screen until dismissed.
+  notifications will remain on screen until dismissed. This feature is currently
+  only available in Google Chrome.

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ You may specify options while loading the magic:
 ```python
 import jupyternotify
 ip = get_ipython()
-ip.register_magics(jupyternotify.JupyterNotifyMagics(ip,
+ip.register_magics(jupyternotify.JupyterNotifyMagics(
+    ip,
     option_name="option_value"
 ))
 ```
 
 The following options exist:
 - `require_interaction` - Boolean, default False. When this is true,
-  notifications will remain on screen untill dismissed.
+  notifications will remain on screen until dismissed.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,19 @@ To test the extension, try
 import time
 time.sleep(5)
 ```
+
+## Options
+
+You may specify options while loading the magic:
+
+```python
+import jupyternotify
+ip = get_ipython()
+ip.register_magics(jupyternotify.JupyterNotifyMagics(ip,
+    option_name="option_value"
+))
+```
+
+The following options exist:
+- `require_interaction` - Boolean, default False. When this is true,
+  notifications will remain on screen untill dismissed.

--- a/jupyternotify/js/notify.js
+++ b/jupyternotify/js/notify.js
@@ -5,9 +5,9 @@ $(document).ready(
             // been sent and avoid duplicates on page reload
             var notifiedDiv = document.createElement("div")
             notifiedDiv.id = "%(notification_uuid)s"
-            element.append(notifiedDiv)                        
+            element.append(notifiedDiv)
         }
-	
+
         // only send notifications if the pageload is complete; this will
         // help stop extra notifications when a saved notebook is loaded,
         // which during testing gives us state "interactive", not "complete"
@@ -15,22 +15,19 @@ $(document).ready(
             // check for the div that signifies that the notification
             // was already sent
             if (document.getElementById("%(notification_uuid)s") === null) {
-                var notificationPayload = {
-                    icon: "/static/base/images/favicon.ico",
-                    body: "Cell Execution Has Finished!!",
-                }
+                var notificationPayload = %(options)s;
                 if (Notification.permission !== 'denied') {
                     if (Notification.permission !== 'granted') { 
                         Notification.requestPermission(function (permission) {
                             if(!('permission' in Notification)) {
                                 Notification.permission = permission
                             }
-                            if (Notification.permission === 'granted') { 
+                            if (Notification.permission === 'granted') {
                                 var notification = new Notification("Jupyter Notebook", notificationPayload)
                                 appendUniqueDiv()
                             }
                         })
-                    } else if (Notification.permission === 'granted') { 
+                    } else if (Notification.permission === 'granted') {
                         var notification = new Notification("Jupyter Notebook", notificationPayload)
                         appendUniqueDiv()
                     }

--- a/jupyternotify/jupyternotify.py
+++ b/jupyternotify/jupyternotify.py
@@ -17,9 +17,9 @@ class JupyterNotifyMagics(Magics):
             jsString = jsFile.read()
         display(Javascript(jsString))
         self.options = json.dumps({
-            'requireInteraction': require_interaction,
-            'body': 'Cell Execution Has Finished!!',
-            'icon': '/static/base/images/favicon.ico',
+            "requireInteraction": require_interaction,
+            "body": "Cell Execution Has Finished!!",
+            "icon": "/static/base/images/favicon.ico",
         })
 
     @cell_magic

--- a/jupyternotify/jupyternotify.py
+++ b/jupyternotify/jupyternotify.py
@@ -1,5 +1,6 @@
 # see https://ipython.org/ipython-doc/3/config/custommagics.html
 # for more details on the implementation here
+import json
 import uuid
 
 from IPython.core.getipython import get_ipython
@@ -10,11 +11,16 @@ from pkg_resources import resource_filename
 
 @magics_class
 class JupyterNotifyMagics(Magics):
-    def __init__(self, shell):
+    def __init__(self, shell, require_interaction=False):
         super(JupyterNotifyMagics, self).__init__(shell)
         with open(resource_filename("jupyternotify", "js/init.js")) as jsFile:
             jsString = jsFile.read()
         display(Javascript(jsString))
+        self.options = json.dumps({
+            'requireInteraction': require_interaction,
+            'body': 'Cell Execution Has Finished!!',
+            'icon': '/static/base/images/favicon.ico',
+        })
 
     @cell_magic
     def notify(self, line, cell):
@@ -27,7 +33,10 @@ class JupyterNotifyMagics(Magics):
         # display our browser notification using javascript
         with open(resource_filename("jupyternotify", "js/notify.js")) as jsFile:
             jsString = jsFile.read()
-        display(Javascript(jsString % {"notification_uuid": notification_uuid}))
+        display(Javascript(jsString % {
+            "notification_uuid": notification_uuid,
+            "options": self.options,
+        }))
 
         # finally, if we generated an exception, print the traceback
         if output.error_in_exec is not None:


### PR DESCRIPTION
I have multiple monitors and don't immediately notice when a notification pops up. So, this adds the ability to make notifications "sticky", i.e. they won't go away until the user dismisses them manually. Default behavior remains the same -- the user has to manually enable this functionality. See README changes for documentation on how to enable it.

I was hoping to get notification sounds to work as well, but it appears that [no browsers support](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification) it yet. Plus, I would have to figure out a place to stick a static sound file for jupyter to serve as the notification sound.