### PR TITLE
ENH added function so that the extension could be loaded normally

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,14 @@ jupyter notebook
 ## Usage
 ### Load inside a Jupyter notebook:
 ``` python
-import jupyternotify
-ip = get_ipython()
-ip.register_magics(jupyternotify.JupyterNotifyMagics)
+%load_ext jupyternotify
 ```
 
 ### Automatically load in all notebooks
 Add the following lines to your ipython startup file:
 ```
-c.InteractiveShellApp.exec_lines = [
-	'import jupyternotify',
-	'ip = get_ipython()',
-	'ip.register_magics(jupyternotify.JupyterNotifyMagics)'
+c.InteractiveShellApp.extensions = [
+    'jupyternotify'
 ]
 ```
 The .ipython startup file can be generated with `ipython profile create [profilename]` and will create a configuration file at `~/.ipython/profile_[profilename]/ipython_config.py'`. Leaving [profilename] blank will create a default profile (see [this](http://ipython.org/ipython-doc/dev/config/intro.html) for more info).
@@ -66,7 +62,9 @@ time.sleep(5)
 
 ## Options
 
-You may specify options while loading the magic:
+NOTE: Currently options cannot be used with `%load_ext` or the ipython startup file instructions above. 
+
+To load the magic with options, you should load it manually by doing the following:
 
 ```python
 import jupyternotify
@@ -77,11 +75,22 @@ ip.register_magics(jupyternotify.JupyterNotifyMagics(
 ))
 ```
 
+or add this to your ipython startup file:
+
+```python
+c.InteractiveShellApp.exec_lines = [
+	'import jupyternotify',
+	'ip = get_ipython()',
+	'ip.register_magics(jupyternotify.JupyterNotifyMagics)'
+]
+```
+
 The following options exist:
 - `require_interaction` - Boolean, default False. When this is true,
   notifications will remain on screen until dismissed. This feature is currently
   only available in Google Chrome.
-  
+
+
 ## Custom Message
 
 You may specify what message you wish the notification to display:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ or add this to your ipython startup file:
 c.InteractiveShellApp.exec_lines = [
 	'import jupyternotify',
 	'ip = get_ipython()',
-	'ip.register_magics(jupyternotify.JupyterNotifyMagics)'
+        'ip.register_magics(jupyternotify.JupyterNotifyMagics(ip, option_name="option_value"))'
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ or add this to your ipython startup file:
 
 ```python
 c.InteractiveShellApp.exec_lines = [
-	'import jupyternotify',
-	'ip = get_ipython()',
-        'ip.register_magics(jupyternotify.JupyterNotifyMagics(ip, option_name="option_value"))'
+    'import jupyternotify',
+    'ip = get_ipython()',
+    'ip.register_magics(jupyternotify.JupyterNotifyMagics(ip, option_name="option_value"))'
 ]
 ```
 

--- a/jupyternotify/__init__.py
+++ b/jupyternotify/__init__.py
@@ -1,1 +1,5 @@
 from .jupyternotify import JupyterNotifyMagics
+
+
+def load_ipython_extension(ipython):
+    ipython.register_magics(JupyterNotifyMagics)


### PR DESCRIPTION
Hi @mdagost! I have added the proper function in the init so the extension can be loaded via

```python
%load_ext jupyternotify
```

I am not sure why this was not there already, but it seemed useful. 

This doesn't work for specify the option upon construction, but that seems to be a special case maybe?