### PR TITLE
Add option to notify only in background

### DIFF
--- a/jupyternotify/js/init.js
+++ b/jupyternotify/js/init.js
@@ -7,3 +7,27 @@ if (!("Notification" in window)) {
         }
     })
 }
+
+// Detect if the window is out of focus.
+window.jupyterNotifyIsInBackground = undefined;
+(function() {
+    // Check document.hidden support
+    var hidden;
+    if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support
+      hidden = "hidden";
+    } else if (typeof document.msHidden !== "undefined") {
+      hidden = "msHidden";
+    } else if (typeof document.webkitHidden !== "undefined") {
+      hidden = "webkitHidden";
+    }
+
+    // Set initial background state
+    if (document[hidden]) {
+      window.jupyterNotifyIsInBackground = true;
+    } else {
+      window.jupyterNotifyIsInBackground = false;
+    }
+
+    window.addEventListener('blur', function() { window.jupyterNotifyIsInBackground = true; }, false);
+    window.addEventListener('focus', function() { window.jupyterNotifyIsInBackground = false; }, false);
+})();

--- a/jupyternotify/js/notify.js
+++ b/jupyternotify/js/notify.js
@@ -16,6 +16,12 @@ $(document).ready(
             // was already sent
             if (document.getElementById("%(notification_uuid)s") === null) {
                 var notificationPayload = %(options)s;
+
+                // We have a notification but the window is active
+                if (notificationPayload.only_in_background && !window.jupyterNotifyIsInBackground) {
+                    appendUniqueDiv();
+                    return;
+                }
                 if (Notification.permission !== 'denied') {
                     if (Notification.permission !== 'granted') { 
                         Notification.requestPermission(function (permission) {

--- a/jupyternotify/jupyternotify.py
+++ b/jupyternotify/jupyternotify.py
@@ -42,6 +42,12 @@ class JupyterNotifyMagics(Magics):
         "--output", action='store_true',
         help="Use last output as message"
     )
+    @argument(
+        "-b",
+        "--only-in-background",
+        action='store_true',
+        help="Only notify if the Jupyter notebook is in the background"
+    )
     @line_cell_magic
     def notify(self, line, cell=None):
 
@@ -52,6 +58,8 @@ class JupyterNotifyMagics(Magics):
         # custom message
         args = parse_argstring(self.notify, line)
         options["body"] = args.message.lstrip("\'\"").rstrip("\'\"")
+
+        options['only_in_background'] = args.only_in_background
 
         # generate a uuid so that we only deliver this notification once, not again
         # when the browser reloads (we append a div to check that)
@@ -107,6 +115,12 @@ class JupyterNotifyMagics(Magics):
         "--output", action='store_true',
         help="Use last output as message"
     )
+    @argument(
+        "-b",
+        "--only-in-background",
+        action='store_true',
+        help="Only notify if the Jupyter notebook is in the background"
+    )
     @line_magic
     def autonotify(self, line):
         # Record options
@@ -114,6 +128,7 @@ class JupyterNotifyMagics(Magics):
         self.options["body"] = args.message.lstrip("\'\"").rstrip("\'\"")
         self.options['autonotify_after'] = args.after
         self.options['autonotify_output'] = args.output
+        self.options['only_in_background'] = args.only_in_background
 
         ### Register events
         ip = get_ipython()


### PR DESCRIPTION
This adds a -b/--only-in-background option that will only notify if the Jupyter notebook is in the background. This allows you to use something like `%autonotify -b -a 5`, which will notify on every cell execution over 5 seconds long, but only if you have switched windows or tabs. I think this is a pretty good experience as if the window is active you will already see that the cell has finished execution, and can avoid the extra notification.