### PR TITLE
Support jupyterlab

### DIFF
--- a/jupyternotify/js/init.js
+++ b/jupyternotify/js/init.js
@@ -7,3 +7,9 @@ if (!("Notification" in window)) {
         }
     })
 }
+
+if(!window.jQuery) {
+    var jq = document.createElement('script');
+    jq.src = "//ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js";
+    document.getElementsByTagName('head')[0].appendChild(jq);
+}


### PR DESCRIPTION
This adds support for jupyterlab. It injects the missing jquery library in contexts where it is missing. This has been tested against jupyter lab 0.35.5.